### PR TITLE
Allow `getType()`, like `getTable()`

### DIFF
--- a/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/internal/AbstractVertxDAO.java
+++ b/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/internal/AbstractVertxDAO.java
@@ -32,6 +32,10 @@ public abstract class AbstractVertxDAO<R extends UpdatableRecord<R>, P, T, FIND_
         this.queryExecutor = queryExecutor;
     }
 
+    public Class<P> getType() {
+        return type;
+    }
+
     public Table<R> getTable() {
         return table;
     }


### PR DESCRIPTION
Like `getTable()`, utilities that juggle a lot of DAOs might want to check out the POJO type the DAO is responsible for.
